### PR TITLE
docs(readme): explain yaegi symbol generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ To call host-compiled functions from the script:
 3. Run `make generate` to refresh Yaegi symbols.
 4. Import and call it from `rule/rule.go`.
 
+Under the hood, `yaegi extract` generates files like `internal/symbol/github_com-dcjanus-yaegi_demo-internal-helper.go`.
+These files define the external symbols the engine can load, and only registered symbols can be used in `rule/rule.go`.
+
 Example (already in this repo):
 
 ```go

--- a/README.md
+++ b/README.md
@@ -63,6 +63,25 @@ Edit `rule/rule.go` and save; the server response updates without restart.
 - `make generate`: regenerate Yaegi symbols
 - `make build`: build binary into `output/yaegi_demo`
 
+## Host Functions
+
+To call host-compiled functions from the script:
+
+1. Add a function to a host package (for example `internal/helper`).
+2. Register that package in `internal/symbol/symbol.go` via a `//go:generate yaegi extract <module path>` line.
+3. Run `make generate` to refresh Yaegi symbols.
+4. Import and call it from `rule/rule.go`.
+
+Example (already in this repo):
+
+```go
+// rule/rule.go
+import "github.com/dcjanus/yaegi_demo/internal/helper"
+
+// ...
+helper.UselessHelper(w, helper.UselessHeader)
+```
+
 ## Project Tree
 
 ```text

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -72,6 +72,9 @@ Code above is wrote by GitHub Copilot.
 3. 运行 `make generate` 重新生成 Yaegi 符号表。
 4. 在 `rule/rule.go` 中导入并调用。
 
+在底层，`yaegi extract` 会生成类似 `internal/symbol/github_com-dcjanus-yaegi_demo-internal-helper.go` 的文件。
+这些文件定义了引擎可加载的外部符号，只有注册过的符号才能在 `rule/rule.go` 里使用。
+
 示例（本仓库已存在）：
 
 ```go

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -63,6 +63,25 @@ Code above is wrote by GitHub Copilot.
 - `make generate`：重新生成 Yaegi 符号表
 - `make build`：构建二进制到 `output/yaegi_demo`
 
+## 宿主机函数
+
+要在脚本中调用宿主机编译的函数：
+
+1. 在宿主包中新增函数（例如 `internal/helper`）。
+2. 在 `internal/symbol/symbol.go` 里添加 `//go:generate yaegi extract <模块路径>` 注册该包。
+3. 运行 `make generate` 重新生成 Yaegi 符号表。
+4. 在 `rule/rule.go` 中导入并调用。
+
+示例（本仓库已存在）：
+
+```go
+// rule/rule.go
+import "github.com/dcjanus/yaegi_demo/internal/helper"
+
+// ...
+helper.UselessHelper(w, helper.UselessHeader)
+```
+
 ## 项目结构
 
 ```text


### PR DESCRIPTION
## Summary
- Explain how Yaegi symbol extraction works and why it is required for host functions.

## Key changes
- Add a short "under the hood" note in both READMEs about generated symbol files.
- Clarify that only registered symbols can be used in `rule/rule.go`.

## Constraints / tradeoffs
- None.

## Testing
- Not run (docs-only changes).
